### PR TITLE
Enable GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,69 @@
+name: Test & Release
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build_test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Build
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test
+      - name: Copy&Paste detection
+        run: npm run cpd
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build_test
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check version
+        run: echo "::set-output name=version::$(echo v$(jq -r .version package.json))"
+        id: version
+      - name: Previous tag
+        run: echo "::set-output name=previous_tag::$(git describe --abbrev=0 --tags)"
+        id: previous_tag
+      - name: Tag release
+        if: steps.version.outputs.version > steps.previous_tag.outputs.previous_tag
+        uses: mathieudutour/github-tag-action@v5.5
+        id: new_tag
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.version.outputs.version }}
+          tag_prefix: ''
+      - name: Generate changelog
+        if: steps.new_tag.outcome == 'success'
+        id: changelog
+        uses: metcalfc/changelog-generator@v1.0.0
+        with:
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        if: steps.new_tag.outcome == 'success'
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.new_tag.outputs.new_tag }}
+          name: "${{ github.event.repository.name }}-${{ steps.new_tag.outputs.new_tag }}"
+          body: |
+            Release ${{ steps.new_tag.outputs.new_tag }} includes the following commits:
+
+            ${{ steps.changelog.outputs.changelog }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Test
-        run: npm run test
+        run: script --quiet --return -c "npm run test" /dev/null
       - name: Copy&Paste detection
         run: npm run cpd
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,16 +8,12 @@ jobs:
   build_test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [8.x, 10.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 8.17.0
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 8.17.0
       - name: Build
         run: npm install
       - name: Lint

--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -1,0 +1,26 @@
+name: Test - PR
+
+on: pull_request
+     
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Build
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test
+      - name: Copy&Paste detection
+        run: npm run cpd

--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -3,19 +3,15 @@ name: Test - PR
 on: pull_request
      
 jobs:
-  build:
+  build_test:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [8.x, 10.x]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 8.17.0
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 8.17.0
       - name: Build
         run: npm install
       - name: Lint

--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Test
-        run: npm run test
+        run: script --quiet --return -c "npm run test" /dev/null
       - name: Copy&Paste detection
         run: npm run cpd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-        - "6"
-services:
-  - docker
-script:
-        - npm run lint
-        - npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.org/bitnami/node-docker-utils.svg?branch=master)](http://travis-ci.org/bitnami/node-docker-utils)
+[![Build Status](https://github.com/bitnami/node-docker-utils/actions/workflows/main.yml/badge.svg)](https://github.com/bitnami/node-docker-utils/actions/workflows/main.yml)
 
 # Docker Utils
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "GPL-2.0",
   "dependencies": {
     "common-utils": "github:bitnami/node-common-utils#v2.2.0",
-    "nami-utils": "github:bitnami/node-common-utils#v2.0.1",
+    "nami-utils": "github:bitnami/nami-utils#v2.0.1",
     "strftime": "^0.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gen-doc": "jsdoc index.js",
     "lint": "gulp lint",
     "test": "gulp test",
+    "cpd": "gulp cpd",
     "ci-test": "gulp ci-test",
     "ci-lint": "gulp ci-lint",
     "ci-cpd": "gulp ci-cpd"
@@ -21,15 +22,15 @@
   "author": "Bitnami",
   "license": "GPL-2.0",
   "dependencies": {
-    "common-utils": "bitnami/node-common-utils#v2.2.0",
-    "nami-utils": "^0.2.1",
+    "common-utils": "github:bitnami/node-common-utils#v2.2.0",
+    "nami-utils": "github:bitnami/node-common-utils#v2.0.1",
     "strftime": "^0.10.0"
   },
   "devDependencies": {
-    "bitnami-gulp-common-tasks": "bitnami/gulp-common-tasks#v2.1.1",
+    "bitnami-gulp-common-tasks": "github:bitnami/gulp-common-tasks#v2.1.1",
     "chai": "^3.5.0",
     "eslint": "^5.16.0",
-    "eslint-config-bitnami": "bitnami/eslint-config-bitnami#v1.0.0",
+    "eslint-config-bitnami": "github:bitnami/eslint-config-bitnami#v1.0.0",
     "eslint-plugin-import": "^1.8.1",
     "gulp": "^3.9.1",
     "jsdoc": "^3.4.1"


### PR DESCRIPTION
Migrated the CI/CD workflow to GitHub Actions from TeamCity. This includes the following:

- Created 2 actions:
  1. Test and release new version if `package.json` version was updated.
  2. Build and test the code in PR.
- Removed travis.
- Updated `package.json` to include the already implemented `gulp cpd` task.
- Updated `package.json` deps to specifically point to GH repos.